### PR TITLE
Changes to interval

### DIFF
--- a/Premiumizer.py
+++ b/Premiumizer.py
@@ -28,12 +28,12 @@ from flask.ext.login import LoginManager, login_required, login_user, logout_use
 from flask.ext.socketio import SocketIO, emit
 from flask_apscheduler import APScheduler
 from gevent import local
+from pySmartDL import SmartDL, utils
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
 from werkzeug.utils import secure_filename
 
 from DownloadTask import DownloadTask
-from pySmartDL import SmartDL, utils
 
 try:
     import myjdapi
@@ -775,7 +775,7 @@ def update():
     response_content = json.loads(r.content)
     if response_content['status'] == "success":
         if not response_content['torrents']:
-            update_interval *= 2
+            update_interval *= 3
         torrents = response_content['torrents']
         idle = parse_tasks(torrents)
     else:
@@ -1252,7 +1252,7 @@ def test_disconnect():
 @socketio.on('hello_server')
 def hello_server(message):
     send_categories()
-    scheduler.scheduler.reschedule_job('update', trigger='interval', seconds=2)
+    scheduler.scheduler.reschedule_job('update', trigger='interval', seconds=1)
     print(message['data'])
 
 

--- a/settings.cfg.tpl
+++ b/settings.cfg.tpl
@@ -2,7 +2,7 @@
 server_port = 5000
 bind_ip = 127.0.0.1
 active_interval = 10
-idle_interval = 120
+idle_interval = 300
 debug_enabled = 0
 
 


### PR DESCRIPTION
Default idle_interval from 2 to 5 minutes & when there are no torrents 15 minutes.
the interval isn't really that important so it can be slower ..

reschedule job on connect to update faster in 1 sec