### PR TITLE
Small bugfix in magnet name extraction

### DIFF
--- a/premiumizer.py
+++ b/premiumizer.py
@@ -1369,7 +1369,7 @@ class MyHandler(events.PatternMatchingEventHandler):
                     else:
                         try:
                             hash = re.search('btih:(.+?)&', magnet).group(1)
-                            name = re.search('&dn=(.+?)&', magnet).group(1)
+                            name = re.search('&dn=(.+?)(&|.torrent)', magnet).group(1)
                         except AttributeError:
                             logger.error('Extracting hash / name from .magnet failed for: %s', watchdir_file)
                             return


### PR DESCRIPTION
In cases where the url in the magnet file contained no additional parameters after the `&dn=` the name extraction failed. This is fixed by searching for either `&` or `.torrent`.