### PR TITLE
fixed issue with docker buildserver not knowing --chown for COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,11 @@ RUN find /usr/local/lib/python2.7/site-packages -mindepth 1 -maxdepth 1 > /filel
 
 FROM python:2.7-alpine
 RUN addgroup -S -g 6006 premiumizer \
-    && adduser -S -D -u 6006 -G premiumizer premiumizer \
-    && mkdir -m 777 /premiumizer \
-    && chown -R 6006:6006 /premiumizer
+    && adduser -S -D -u 6006 -G premiumizer premiumizer
+COPY --from=0 /usr/local/lib/python2.7/site-packages /usr/local/lib/python2.7/site-packages/ 
+COPY . /premiumizer/
+RUN chown -R premiumizer:premiumizer /premiumizer && chmod -R 777 /premiumizer
 USER premiumizer
-COPY --chown=premiumizer:premiumizer --from=0 /usr/local/lib/python2.7/site-packages /usr/local/lib/python2.7/site-packages/ 
-COPY --chown=premiumizer:premiumizer . /premiumizer/
 WORKDIR /premiumizer
 EXPOSE 5000
 ENTRYPOINT ["python", "premiumizer.py"]


### PR DESCRIPTION
Replaces the current method of setting ownership with another RUN step.