### PR TITLE
Fixes Startup Error with Aria2 and Downloadspeed

### DIFF
--- a/premiumizer.py
+++ b/premiumizer.py
@@ -265,7 +265,7 @@ class PremConfig:
                 if self.download_speed == -1:
                     download_speed = 0
                 else:
-                    download_speed = str(cfg.download_speed + 'M')
+                    download_speed = str(str(self.download_speed) + 'M')
                 self.aria.aria2.changeGlobalOption(self.aria2_token, {'max-download-limit': download_speed})
                 self.aria2_connected = 1
             except Exception as e:


### PR DESCRIPTION
If Aria2 is used and the Downloadspeed is Limited Two Exceptions came up:
First a 'cfg is not defined'
Second: unsupported operand type(s) for +: 'int' and 'str'