### PR TITLE
Add Docker entrypoint for PUID and PGID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,13 @@ RUN find /usr/local/lib/python2.7/site-packages -mindepth 1 -maxdepth 1 > /filel
     && apt-get install tzdata
 
 FROM python:2.7-alpine
-RUN addgroup -S -g 6006 premiumizer \
-    && adduser -S -D -u 6006 -G premiumizer premiumizer
+RUN apk --no-cache add shadow \
+    && addgroup -S -g 6006 premiumizer \
+    && adduser -S -D -u 6006 -G premiumizer -s /bin/sh premiumizer
 COPY --from=0 /usr/local/lib/python2.7/site-packages /usr/local/lib/python2.7/site-packages/
 COPY --from=0 /usr/share/zoneinfo /usr/share/zoneinfo/
 COPY . /premiumizer/
-RUN chown -R premiumizer:premiumizer /premiumizer && chmod -R 777 /premiumizer \
-    && sed -i "s/127.0.0.1/0.0.0.0/g" premiumizer/settings.cfg.tpl
-USER premiumizer
+RUN chmod -R 777 /premiumizer && sed -i "s/127.0.0.1/0.0.0.0/g" premiumizer/settings.cfg.tpl
 WORKDIR /premiumizer
 EXPOSE 5000
-ENTRYPOINT ["python", "premiumizer.py"]
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+PUID=${PUID:-6006}
+PGID=${PGID:-6006}
+
+groupmod -o -g "$PGID" premiumizer
+usermod -o -u "$PUID" premiumizer
+
+su - premiumizer -p -c 'python premiumizer.py'


### PR DESCRIPTION
This should essentially solve configuration issues for Synology users (see discussion at #88). I'm loosely following [this approach from the Linuxserver images](https://github.com/linuxserver/docker-baseimage-ubuntu/blob/6138a3250c5a8fa8848b6ec78f1ca2b20707fe6d/root/etc/cont-init.d/10-adduser). Please feel free to edit.

To play around with this, I've created a temporary push at https://hub.docker.com/r/janauer/premiumizer. I'll take it down once this PR is either merged or closed.

**Note** that running `docker exec` will now run as `root`, and only premiumizer itself will be run as `premiumizer` user.