### PR TITLE
Fixes for docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY . /premiumizer/
 RUN chmod -R 777 /premiumizer && sed -i "s/127.0.0.1/0.0.0.0/g" premiumizer/conf/settings.cfg.tpl
 WORKDIR /premiumizer
 EXPOSE 5000
-ENTRYPOINT ["./premiumizer/docker-entrypoint.sh"]
+ENTRYPOINT ["/bin/sh","./premiumizer/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Install NzbToMedia & pywin32 & Microsoft Visual c++ python compiler:
 ### OS X
 Install [brew](http://brew.sh/), use brew to install python
 
-1. ```git clonehttps://github.com/piejanssens/premiumizer.git```
+1. ```git clone https://github.com/piejanssens/premiumizer.git```
 2. ```cd premiumizer```
 3. ```virtualenv virtualenv```
 4. ```source virtualenv/bin/activate```
@@ -111,6 +111,14 @@ Install [brew](http://brew.sh/), use brew to install python
 Now use your browser to access [http://127.0.0.1:5000/](http://127.0.0.1:5000/)
 
 Extra: Google how you can turn it into a service and run it in background
+
+### Docker
+Build the image and run the container:
+1. ```git clone https://github.com/piejanssens/premiumizer.git```
+2. ```cd premiumizer```
+3. ```docker build -t REPO/TAG . ```
+4. ```docker run -d -p 5000:5000 -e TZ=Europe/London -e PUID=1000 -e PGID=1000 -v <host_path>:/premiumizer/conf -v <host_path>:/blackhole -v <host_path>:/downloads REPO/TAG```
+Manually setting PUID and PGID might be necessary for the bind-mounts (depends on your permission setup).
 
 ## Updating
 Update from the settings page / enable automatic updates

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Build the image and run the container:
 2. ```cd premiumizer```
 3. ```docker build -t REPO/TAG . ```
 4. ```docker run -d -p 5000:5000 -e TZ=Europe/London -e PUID=1000 -e PGID=1000 -v <host_path>:/premiumizer/conf -v <host_path>:/blackhole -v <host_path>:/downloads REPO/TAG```
+
 Manually setting PUID and PGID might be necessary for the bind-mounts (depends on your permission setup).
 
 ## Updating

--- a/premiumizer/docker-entrypoint.sh
+++ b/premiumizer/docker-entrypoint.sh
@@ -6,4 +6,4 @@ PGID=${PGID:-6006}
 groupmod -o -g "$PGID" premiumizer
 usermod -o -u "$PUID" premiumizer
 
-su - premiumizer -p -c 'python premiumizer.py'
+su - premiumizer -p -c 'python ./premiumizer/premiumizer.py'


### PR DESCRIPTION
I encountered some issues while building and running premiumizer on windows with linux containers. Those changes fix the following:
*  force using /bin/sh by specifying it as entrypoint. It did work in a Ubuntu VM, but on Windows it always gave me a "not such file or directory error". I assume it defaults to a different shell (/bin/bash maybe? it's not part of the python base image from what I've seen)
*  fix the path to premiumizer.py in the startup script
*  add an example for docker to the readme