### PR TITLE
bugfix

### DIFF
--- a/premiumizer/premiumizer.py
+++ b/premiumizer/premiumizer.py
@@ -1548,7 +1548,7 @@ def parse_tasks(transfers):
             if 'ETA is' in transfer['message']:
                 eta = transfer['message'].split("ETA is", 1)[1]
             elif 'peers,' in transfer['message'] or 'peer,' in transfer['message'] or 'usenet,' in transfer['message']:
-                eta = transfer['message'].split(',')[2]
+                eta = transfer['message'].rsplit(',', 2)[2]
             elif transfer['message']:
                 eta = transfer['message']
         except:
@@ -1557,7 +1557,7 @@ def parse_tasks(transfers):
             if 'Downloading at' in transfer['message']:
                 speed = transfer['message'].split("Downloading at", 1)[1].split(". ", 1)[0]
             elif 'peers,' in transfer['message'] or 'peer,' in transfer['message'] or 'usenet,' in transfer['message']:
-                speed = transfer['message'].split(',')[0]
+                speed = transfer['message'].rsplit(',', 2)[0]
         except:
             pass
         try:
@@ -1565,7 +1565,7 @@ def parse_tasks(transfers):
                 size = transfer['message'].split("of ", 1)[1].split(" finished", 1)[0]
                 progress = int(transfer['message'].split("s.", 1)[1].split("% of", 1)[0])
             elif 'peers,' in transfer['message'] or 'peer,' in transfer['message'] or 'usenet,' in transfer['message']:
-                size = transfer['message'].split(',')[1]
+                size = transfer['message'].rsplit(',', 2)[1]
                 progress = int(round(float(transfer['progress']) * 100))
             else:
                 progress = int(round(float(transfer['progress']) * 100))

--- a/premiumizer/settings.cfg.tpl
+++ b/premiumizer/settings.cfg.tpl
@@ -91,4 +91,4 @@ updated = 1
 auto_update = 0
 update_date = Never
 config_version = 2.6
-req_version = 9.6
+req_version = 9.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pathtools==0.1.2
 pySmartDL==1.3.2
 pycryptodome==3.8.2
 python-dateutil==2.8.0
-python-engineio==3.9.0
+python-engineio==3.9.1
 python-socketio==4.3.0
 requests==2.22.0
 six==1.12


### PR DESCRIPTION
bump python-engineio some small bugfix with that new option

bugfix cloud info display since prem.me started using an extra , e.g. 1,500 KB/S to display 1500 :/ rsplit ftw =D