### PR TITLE
Fix/dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,6 @@ COPY premiumizer /app
 
 WORKDIR /app
 
+VOLUME /conf
 EXPOSE 5000
 CMD ["python", "/app/premiumizer.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ RUN pip install --prefix /install -r requirements.txt
 
 FROM base
 
-RUN addgroup -S -g 1000 premiumizer \
-	&& adduser -S -D -u 1000 -G premiumizer -s /bin/sh premiumizer
-USER premiumizer
+RUN apk add --update --no-cache su-exec shadow \
+	&& addgroup -S -g 6006 premiumizer \
+	&& adduser -S -D -u 6006 -G premiumizer -s /bin/sh premiumizer
 
 COPY --from=builder /install /usr/local
 COPY premiumizer /app
@@ -23,4 +23,6 @@ WORKDIR /app
 
 VOLUME /conf
 EXPOSE 5000
-CMD ["python", "/app/premiumizer.py"]
+
+ENTRYPOINT ["/bin/sh","/app/docker-entrypoint.sh"]
+CMD ["/usr/local/bin/python", "/app/premiumizer.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ RUN pip install --prefix /install -r requirements.txt
 
 FROM base
 
+RUN addgroup -S -g 1000 premiumizer \
+	&& adduser -S -D -u 1000 -G premiumizer -s /bin/sh premiumizer
+USER premiumizer
+
 COPY --from=builder /install /usr/local
 COPY premiumizer /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /install
 
 COPY requirements.txt ./premiumizer /install/
 
-RUN apk add --update --virtual build-dependencies libffi-dev openssl-dev python-dev py-pip build-base
+RUN apk add --update --no-cache libffi-dev openssl-dev python-dev py-pip build-base
 RUN pip install --prefix /install -r requirements.txt
 
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
-ARG SOURCE_COMMIT
+FROM python:3.7-alpine as base
 
-FROM python:3.7
-ENV SOURCE_COMMIT $SOURCE_COMMIT
-COPY requirements.txt /premiumizer/
-RUN find /usr/local/lib/python3.7/site-packages -mindepth 1 -maxdepth 1 > /filelist \
-    && pip install -r premiumizer/requirements.txt \
-    && xargs rm -rf < /filelist \
-    && apt-get install tzdata
-    
-FROM python:3.7-alpine
-RUN apk --no-cache add shadow \
-    && addgroup -S -g 6006 premiumizer \
-    && adduser -S -D -u 6006 -G premiumizer -s /bin/sh premiumizer
-COPY --from=0 /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages/
-COPY --from=0 /usr/share/zoneinfo /usr/share/zoneinfo/
-COPY . /premiumizer/
-RUN chmod -R 777 /premiumizer
-WORKDIR /premiumizer
+FROM base as builder
+
+RUN mkdir /install
+WORKDIR /install
+
+COPY requirements.txt ./premiumizer /install/
+
+RUN apk add --update --virtual build-dependencies libffi-dev openssl-dev python-dev py-pip build-base
+RUN pip install --prefix /install -r requirements.txt
+
+FROM base
+
+COPY --from=builder /install /usr/local
+COPY premiumizer /app
+
+WORKDIR /app
+
 EXPOSE 5000
-ENTRYPOINT ["/bin/sh","./premiumizer/docker-entrypoint.sh"]
+CMD ["python", "/app/premiumizer.py"]

--- a/premiumizer/docker-entrypoint.sh
+++ b/premiumizer/docker-entrypoint.sh
@@ -3,7 +3,9 @@
 PUID=${PUID:-6006}
 PGID=${PGID:-6006}
 
-groupmod -o -g "$PGID" premiumizer
-usermod -o -u "$PUID" premiumizer
+groupmod -o -g "$PGID" premiumizer || true
+usermod -o -u "$PUID" premiumizer || true
 
-su - premiumizer -p -c 'python ./premiumizer/premiumizer.py'
+chown -R premiumizer:premiumizer /conf || true
+
+exec su-exec premiumizer "$@"


### PR DESCRIPTION
* It fixes gcc `unknown symbols` as it was using `python:3.7` (debian buster) as base. It uses `python:3.7-alpine` for everything now.
* No more `chmod -R 777`. We don't need this anyway but it sets ownership for `/conf`.
* It keeps ability to set custom PUID/PGID by env variables.