### PR TITLE
feat: multi arch docker build

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,14 +1,20 @@
-FROM python:3.7-alpine as base
+FROM arm32v7/python:3.7-alpine as base
 FROM base as builder
+
+# For cross building on amd64 host
+COPY qemu-arm-static /usr/bin
 
 RUN mkdir /install
 WORKDIR /install
 COPY requirements.txt ./premiumizer /install/
 
 RUN apk add --update --no-cache libffi-dev openssl-dev python-dev py-pip build-base
-RUN pip install --prefix /install -r requirements.txt
+RUN pip install --no-cache-dir --prefix /install -r requirements.txt
 
 FROM base
+
+# For cross building on amd64 host
+COPY qemu-arm-static /usr/bin
 
 RUN apk add --update --no-cache su-exec shadow \
 	&& addgroup -S -g 6006 premiumizer \

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,14 +1,20 @@
-FROM python:3.7-alpine as base
+FROM arm64v8/python:3.7-alpine as base
 FROM base as builder
+
+# For cross building on amd64 host
+COPY qemu-aarch64-static /usr/bin
 
 RUN mkdir /install
 WORKDIR /install
 COPY requirements.txt ./premiumizer /install/
 
 RUN apk add --update --no-cache libffi-dev openssl-dev python-dev py-pip build-base
-RUN pip install --prefix /install -r requirements.txt
+RUN pip install --no-cache-dir --prefix /install -r requirements.txt
 
 FROM base
+
+# For cross building on amd64 host
+COPY qemu-aarch64-static /usr/bin
 
 RUN apk add --update --no-cache su-exec shadow \
 	&& addgroup -S -g 6006 premiumizer \

--- a/README.md
+++ b/README.md
@@ -70,11 +70,53 @@ $ python premiumizer/premiumizer.py
 
 ### Docker
 
+### Supported Architectures
+Based on [this](https://github.com/cgiraldo/docker-hello-multiarch) approach, we support `amd64`, `arm32v7` & `arm64v8`.
+
+Our image has a multiarch manifest, so by pulling `piejanssens/premiumizer:latest` it should retrieve the correct image for your arch, but you can also pull specific arch via tags.
+
+| Architecture | Tag |
+| :----: | --- |
+| x86-64 | amd64 |
+| arm64 | arm64v8 |
+| armhf | arm32v7 |
+
 #### General
 You need to set the correct PUID and PGID equal to the user that has rw access to the mounted volumes.
 
+##### Command line
 ```
-docker run -d -p 5000:5000 -e TZ=Europe/London -e PUID=1000 -e PGID=1000 -v <host_path>:/conf -v <host_path>:/blackhole -v <host_path>:/downloads piejanssens/premiumizer:latest
+docker run \
+  --name premiumizer \
+  -e PUID=1000 \
+  -e PGID=1000 \
+  -e TZ=Europe/London \
+  -p 5000:5000 \
+  -v /path/to/conf:/conf \
+  -v /path/to/blackhole:/blackhole \
+  -v /path/to/downloads:/downloads \
+  --restart unless-stopped \
+  piejanssens/premiumizer
+```
+##### docker-compose
+```
+---
+version: "3.6"
+services:
+  premiumizer:
+    image: piejanssens/premiumizer
+    container_name: premiumizer
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/London
+    volumes:
+      - /path/to/conf:/conf
+      - /path/to/blackhole:/blackhole
+      - /path/to/downloads:/downloads
+    ports:
+      - 5000:5000
+    restart: unless-stopped
 ```
 
 #### Synology DSM

--- a/hooks/post_checkout
+++ b/hooks/post_checkout
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Get architecture from Dockerfile.arch filename
+BUILD_ARCH=$(echo "${DOCKERFILE_PATH}" | cut -d '.' -f 2)
+
+# For amd64 filename is Dockerfile
+[ "${BUILD_ARCH}" == "Dockerfile" ] && \
+    { echo 'qemu-user-static: Download not required for current arch'; exit 0; }
+
+case ${BUILD_ARCH} in
+    amd64   ) QEMU_ARCH="x86_64" ;;
+    arm32v7 ) QEMU_ARCH="arm" ;;
+    arm64v8 ) QEMU_ARCH="aarch64" ;
+ esac
+
+QEMU_USER_STATIC_DOWNLOAD_URL="https://github.com/multiarch/qemu-user-static/releases/download"
+QEMU_USER_STATIC_LATEST_TAG=$(curl -s https://api.github.com/repos/multiarch/qemu-user-static/tags \
+    | grep 'name.*v[0-9]' \
+    | head -n 1 \
+    | cut -d '"' -f 4)
+
+curl -SL "${QEMU_USER_STATIC_DOWNLOAD_URL}/${QEMU_USER_STATIC_LATEST_TAG}/qemu-${QEMU_ARCH}-static.tar.gz" \
+    | tar xzv

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+curl -SL "https://download.docker.com/linux/static/stable/x86_64/docker-19.03.9.tgz" | tar xzv docker/docker --transform='s/.*/docker-cli/'
+mkdir ~/.docker
+
+# Add auths and experimental to docker-cli config
+echo '{"auths": '$DOCKERCFG',"experimental":"enabled"}' > ~/.docker/config.json
+
+# Check if all arch images are in dockerhub
+AMD64_IMAGE="${DOCKER_REPO}:amd64"
+ARM64_IMAGE="${DOCKER_REPO}:arm64v8"
+ARM32_IMAGE="${DOCKER_REPO}:arm32v7"
+
+echo "checking if ${AMD64_IMAGE} Manifest exists"
+if ! ./docker-cli manifest inspect ${AMD64_IMAGE}; then AMD64_IMAGE='' ; fi
+echo "checking if ${ARM32_IMAGE} Manifest exists"
+if ! ./docker-cli manifest inspect ${ARM32_IMAGE}; then ARM32_IMAGE='' ; fi
+echo "checking if ${ARM64_IMAGE} Manifest exists"
+if ! ./docker-cli manifest inspect ${ARM64_IMAGE}; then ARM64_IMAGE='' ; fi
+
+echo "Creating multiarch manifest"
+./docker-cli manifest create ${DOCKER_REPO}:latest $AMD64_IMAGE $ARM32_IMAGE $ARM64_IMAGE
+if [ -n "${ARM32_IMAGE}" ]; then
+  ./docker-cli manifest annotate ${DOCKER_REPO}:latest $ARM32_IMAGE --os linux --arch arm
+fi
+if [ -n "${ARM64_IMAGE}" ]; then
+  ./docker-cli manifest annotate ${DOCKER_REPO}:latest $ARM64_IMAGE --os linux --arch arm64
+fi
+./docker-cli manifest push ${DOCKER_REPO}:latest
+
+rm -r docker-cli ~/.docker

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+BUILD_ARCH=$(echo "${DOCKERFILE_PATH}" | cut -d '.' -f 2)
+
+[ "${BUILD_ARCH}" == "Dockerfile" ] && \
+    { echo 'qemu-user-static: Registration not required for current arch'; exit 0; }
+
+docker run --rm --privileged multiarch/qemu-user-static:register --reset


### PR DESCRIPTION
Added Dockerfiles & hooks for auto building premiumizer on `amd64`, `arm32v7` & `arm64v8`.
It also improves documentation for docker building.
Closes #255 #243 

@piejanssens, you need to setup [Docker Hub](https://hub.docker.com/repository/docker/piejanssens/premiumizer/builds/edit) in this way:
| Source Type | Source | Docker Tag | Dockerfile Location | Build Context | Autobuild | Build Caching |
| :----: | --- | --- | --- | --- | --- | --- |
| Branch | master | amd64 | Dockerfile | / | true | true |
| Branch | master | arm32v7 | Dockerfile.arm32v7 | / | true | true |
| Branch | master | arm64v8 | Dockerfile.arm64v8 | / | true | true |