### PR TITLE
Fix custom download locations on Linux

### DIFF
--- a/premiumizer/premiumizer.py
+++ b/premiumizer/premiumizer.py
@@ -421,7 +421,7 @@ class PremConfig:
                 cat_name = prem_config.get('categories', ('cat_name' + str([x])))
                 cat_dir = prem_config.get('categories', ('cat_dir' + str([x])))
                 if cat_name != '':
-                    if cat_dir == '' or ('//' not in cat_dir and '\\' not in cat_dir):
+                    if cat_dir == '' or ('/' not in cat_dir and '\\' not in cat_dir):
                         if cat_name == 'default':
                             cat_dir = self.download_location
                         else:


### PR DESCRIPTION
Directories are specified as '/mnt/video/movies'.

The offending line would be checking for a valid path looking for `//` or `\`, which would fail on linux paths reverting to the default location + category name.

I've tested this on a Raspberry Pi running DietPi, which is Debian based. I did not have a chance to test on Windows, but I suppose it'd be OK.

@neox387  -- would you remember why the check for `//` on that line?