### PR TITLE
Allow write access on downloaded files

### DIFF
--- a/premiumizer/docker-entrypoint.sh
+++ b/premiumizer/docker-entrypoint.sh
@@ -8,4 +8,7 @@ usermod -o -u "$PUID" premiumizer || true
 
 chown -R premiumizer:premiumizer /conf || true
 
+# Allow write access on downloaded files to group and others
+umask 0000
+
 exec su-exec premiumizer "$@"


### PR DESCRIPTION
Using umask 0000 to allow write access on downloaded files to group and others.
See http://widerin.net/blog/change-umask-in-docker-containers/

This should fix #289