### PR TITLE
Changed python-dev to python3-dev for ARM builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /install
 COPY requirements.txt ./premiumizer /install/
 
 RUN apk add --update --no-cache libffi-dev openssl-dev python3-dev py-pip build-base tzdata
-RUN pip install --prefix /install -r requirements.txt
+RUN pip install --no-cache-dir --prefix /install -r requirements.txt
 
 FROM base
 

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -8,7 +8,7 @@ RUN mkdir /install
 WORKDIR /install
 COPY requirements.txt ./premiumizer /install/
 
-RUN apk add --update --no-cache libffi-dev openssl-dev python3-dev py-pip build-base
+RUN apk add --update --no-cache libffi-dev openssl-dev python3-dev py-pip build-base tzdata
 RUN pip install --no-cache-dir --prefix /install -r requirements.txt
 
 FROM base
@@ -21,6 +21,7 @@ RUN apk add --update --no-cache su-exec shadow libstdc++ \
 	&& adduser -S -D -u 6006 -G premiumizer -s /bin/sh premiumizer
 
 COPY --from=builder /install /usr/local
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY premiumizer /app
 
 WORKDIR /app

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -8,7 +8,7 @@ RUN mkdir /install
 WORKDIR /install
 COPY requirements.txt ./premiumizer /install/
 
-RUN apk add --update --no-cache libffi-dev openssl-dev python-dev py-pip build-base
+RUN apk add --update --no-cache libffi-dev openssl-dev python3-dev py-pip build-base
 RUN pip install --no-cache-dir --prefix /install -r requirements.txt
 
 FROM base

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -8,7 +8,7 @@ RUN mkdir /install
 WORKDIR /install
 COPY requirements.txt ./premiumizer /install/
 
-RUN apk add --update --no-cache libffi-dev openssl-dev python3-dev py-pip build-base
+RUN apk add --update --no-cache libffi-dev openssl-dev python3-dev py-pip build-base tzdata
 RUN pip install --no-cache-dir --prefix /install -r requirements.txt
 
 FROM base
@@ -21,6 +21,7 @@ RUN apk add --update --no-cache su-exec shadow libstdc++ \
 	&& adduser -S -D -u 6006 -G premiumizer -s /bin/sh premiumizer
 
 COPY --from=builder /install /usr/local
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY premiumizer /app
 
 WORKDIR /app

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -8,7 +8,7 @@ RUN mkdir /install
 WORKDIR /install
 COPY requirements.txt ./premiumizer /install/
 
-RUN apk add --update --no-cache libffi-dev openssl-dev python-dev py-pip build-base
+RUN apk add --update --no-cache libffi-dev openssl-dev python3-dev py-pip build-base
 RUN pip install --no-cache-dir --prefix /install -r requirements.txt
 
 FROM base


### PR DESCRIPTION
Could fix issue #304. Before this change building the image always stopped at this step, now it has been building for a while. Not sure if maybe Docker Hub, or wherever the actual image gets built, might time out at some point, though. It has been building on my testing machine for a while now (maybe 2h so far?), and it's not done yet, but making progress. Qemu is just not all that fast for me.

Edit: The build just finished and didn't throw any errors.